### PR TITLE
feat: add endpoint for retrieving restaurant opinions

### DIFF
--- a/src/restaurant/controllers/restaurant.controller.js
+++ b/src/restaurant/controllers/restaurant.controller.js
@@ -3,6 +3,9 @@ import {
   doc,
   getDoc,
   getDocs,
+  limit,
+  orderBy,
+  query,
   updateDoc,
 } from "firebase/firestore";
 
@@ -117,6 +120,25 @@ export const getNumberOfOpinions = async (req, res) => {
     totalOpinions += opinionsSnapshot.size;
   }
   return res.status(200).json({ numberOfOpinions: totalOpinions });
+};
+
+export const getRestaurantOpinions = async (req, res) => {
+  const { restaurantId } = req.params;
+  const { l } = req.query;
+  const restaurant = await getDoc(
+    doc(FIREBASE_DB, "restaurants", restaurantId)
+  );
+  let opinionsQuery = query(
+    collection(restaurant.ref, "opinions"),
+    orderBy("rating", "desc"),
+    limit(l ? Number(l) : 5)
+  );
+  const opinionsSnapshot = await getDocs(opinionsQuery);
+  const opinions = [];
+  opinionsSnapshot.forEach((opinion) => {
+    opinions.push({ ...opinion.data(), id: opinion.id });
+  });
+  return res.status(200).json(opinions);
 };
 
 export const getRestaurants = async (req, res) => {

--- a/src/restaurant/routes/restaurant.routes.js
+++ b/src/restaurant/routes/restaurant.routes.js
@@ -8,6 +8,7 @@ import {
   getNumberOfRestaurants,
   getRestaurantById,
   getRestaurantByUser,
+  getRestaurantOpinions,
   getRestaurantVisits,
   getRestaurantVisitsByDate,
   getRestaurantVisitsByRange,
@@ -26,6 +27,7 @@ router.get("/restaurants/numberOfOpinions", getNumberOfOpinions);
 router.get("/restaurant/search", searchRestaurant);
 router.get("/restaurant/restaurantByUser", getRestaurantByUser);
 router.get("/restaurant/:restaurantId", getRestaurantById);
+router.get("/restaurant/:restaurantId/opinions", getRestaurantOpinions);
 router.get("/restaurant/:restaurantId/visit", updateRestaurantVisits);
 router.get("/restaurant/:restaurantId/visits", getRestaurantVisits);
 router.get("/restaurant/:restaurantId/visitsByDate", getRestaurantVisitsByDate);

--- a/src/restaurant/test/restaurant.spec.js
+++ b/src/restaurant/test/restaurant.spec.js
@@ -199,3 +199,13 @@ describe("Testing getting restaurant visits by range", () => {
     expect(res.body.visits).toBe(0);
   });
 });
+
+describe("Testing getting restaurant opinions", () => {
+  it("Can get restaurant opinions", async () => {
+    const res = await request(app).get(
+      `/api/restaurant/${restaurantId}/opinions`
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The code changes include adding a new endpoint `/restaurant/:restaurantId/opinions` to the API that allows users to retrieve the opinions for a specific restaurant. This endpoint accepts the `restaurantId` as a parameter and returns the opinions sorted by rating in descending order. The number of opinions returned can be limited by the optional query parameter `l`. This feature enhances the functionality of the application by providing users with the ability to view and analyze the opinions of a restaurant.